### PR TITLE
Update ocr.py

### DIFF
--- a/examples/async/ocr.py
+++ b/examples/async/ocr.py
@@ -7,6 +7,6 @@ ocr = await client.ocr(url=...)
 
 # From bytes:
 from io import BytesIO
-ocr = await client.ocr(fp=BytesIO(...))
+ocr = await client.ocr(source=BytesIO(...))
 
 ocr.text # ...

--- a/examples/async/ocr.py
+++ b/examples/async/ocr.py
@@ -3,7 +3,7 @@ from openrobot.api_wrapper import AsyncClient
 client = AsyncClient(...)
 
 # From URL:
-ocr = await client.ocr(url=...)
+ocr = await client.ocr(source=...)
 
 # From bytes:
 from io import BytesIO


### PR DESCRIPTION
Client.ocr doesn't take the keyword argument `fp`, the help() page says it takes a `source`. Which can either be a URL or a BytesIO object, hence, the examples have been updated to reflect the same.